### PR TITLE
Extend query interface to support closed in addition to half-open intervals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sif-itree"
 description = "simple, immutable, flat interval tree"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Adam Reichold <adam.reichold@t-online.de>"]
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub type Item<K, V> = (Range<K>, V);
 /// The nodes of which the tree is built consisting of an item and the maximum of the interval upper bounds in the subtree
 pub type Node<K, V> = (Item<K, V>, K);
 
-/// Interval tree mapping half-open intervals with boundaries of type `K` to values of type `V`
+/// Interval tree mapping half-open or closed intervals with boundaries of type `K` to values of type `V`
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,4 +1,4 @@
-use std::ops::{ControlFlow, Range};
+use std::ops::{ControlFlow, Range, RangeInclusive};
 
 #[cfg(feature = "rayon")]
 use rayon::join;
@@ -10,9 +10,14 @@ where
     S: AsRef<[Node<K, V>]>,
 {
     /// Query for all intervals overlapping the given interval
-    pub fn query<'a, H, R>(&'a self, interval: Range<K>, handler: H) -> ControlFlow<R>
+    ///
+    /// The stored intervals are interpeted as half-open or closed,
+    /// depending on the type of the given query interval,
+    /// either [`Range`] or [`RangeInclusive`].
+    pub fn query<'a, I, H, R>(&'a self, interval: I, handler: H) -> ControlFlow<R>
     where
         K: Ord,
+        I: Interval<K>,
         H: FnMut(&'a Item<K, V>) -> ControlFlow<R>,
     {
         let nodes = self.nodes.as_ref();
@@ -26,10 +31,15 @@ where
 
     #[cfg(feature = "rayon")]
     /// Query for all intervals overlapping the given interval, in parallel
-    pub fn par_query<'a, H, R>(&'a self, interval: Range<K>, handler: H) -> ControlFlow<R>
+    ///
+    /// The stored intervals are interpeted as half-open or closed,
+    /// depending on the type of the given query interval,
+    /// either [`Range`] or [`RangeInclusive`].
+    pub fn par_query<'a, I, H, R>(&'a self, interval: I, handler: H) -> ControlFlow<R>
     where
         K: Ord + Send + Sync,
         V: Sync,
+        I: Interval<K> + Sync,
         H: Fn(&'a Item<K, V>) -> ControlFlow<R> + Sync,
         R: Send,
     {
@@ -43,14 +53,58 @@ where
     }
 }
 
-struct QueryArgs<K, H> {
-    interval: Range<K>,
+pub trait Interval<K> {
+    fn go_left(&self, max: &K) -> bool;
+    fn go_right(&self, start: &K) -> bool;
+    fn overlaps(&self, end: &K) -> bool;
+}
+
+impl<K> Interval<K> for Range<K>
+where
+    K: Ord,
+{
+    fn go_left(&self, max: &K) -> bool {
+        &self.start < max
+    }
+
+    fn go_right(&self, start: &K) -> bool {
+        &self.end > start
+    }
+
+    fn overlaps(&self, end: &K) -> bool {
+        &self.start < end
+    }
+}
+
+impl<K> Interval<K> for RangeInclusive<K>
+where
+    K: Ord,
+{
+    fn go_left(&self, max: &K) -> bool {
+        self.start() <= max
+    }
+
+    fn go_right(&self, start: &K) -> bool {
+        self.end() >= start
+    }
+
+    fn overlaps(&self, end: &K) -> bool {
+        self.start() <= end
+    }
+}
+
+struct QueryArgs<I, H> {
+    interval: I,
     handler: H,
 }
 
-fn query<'a, K, V, H, R>(args: &mut QueryArgs<K, H>, mut nodes: &'a [Node<K, V>]) -> ControlFlow<R>
+fn query<'a, I, H, K, V, R>(
+    args: &mut QueryArgs<I, H>,
+    mut nodes: &'a [Node<K, V>],
+) -> ControlFlow<R>
 where
     K: Ord,
+    I: Interval<K>,
     H: FnMut(&'a (Range<K>, V)) -> ControlFlow<R>,
 {
     loop {
@@ -61,17 +115,17 @@ where
         let mut go_left = false;
         let mut go_right = false;
 
-        if args.interval.start < mid.1 {
+        if args.interval.go_left(&mid.1) {
             if !left.is_empty() {
                 go_left = true;
             }
 
-            if args.interval.end > (mid.0).0.start {
+            if args.interval.go_right(&(mid.0).0.start) {
                 if !right.is_empty() {
                     go_right = true;
                 }
 
-                if args.interval.start < (mid.0).0.end {
+                if args.interval.overlaps(&(mid.0).0.end) {
                     (args.handler)(&mid.0)?;
                 }
             }
@@ -91,10 +145,14 @@ where
 }
 
 #[cfg(feature = "rayon")]
-fn par_query<'a, K, V, H, R>(args: &QueryArgs<K, H>, mut nodes: &'a [Node<K, V>]) -> ControlFlow<R>
+fn par_query<'a, I, H, K, V, R>(
+    args: &QueryArgs<I, H>,
+    mut nodes: &'a [Node<K, V>],
+) -> ControlFlow<R>
 where
     K: Ord + Send + Sync,
     V: Sync,
+    I: Interval<K> + Sync,
     H: Fn(&'a (Range<K>, V)) -> ControlFlow<R> + Sync,
     R: Send,
 {
@@ -106,17 +164,17 @@ where
         let mut go_left = false;
         let mut go_right = false;
 
-        if args.interval.start < mid.1 {
+        if args.interval.go_left(&mid.1) {
             if !left.is_empty() {
                 go_left = true;
             }
 
-            if args.interval.end > (mid.0).0.start {
+            if args.interval.go_right(&(mid.0).0.start) {
                 if !right.is_empty() {
                     go_right = true;
                 }
 
-                if args.interval.start < (mid.0).0.end {
+                if args.interval.overlaps(&(mid.0).0.end) {
                     (args.handler)(&mid.0)?;
                 }
             }
@@ -187,6 +245,46 @@ mod tests {
             .unwrap()
     }
 
+    #[test]
+    fn query_random_inclusive() {
+        const DOM: Range<i32> = -1000..1000;
+        const LEN: usize = 1000_usize;
+
+        TestRunner::default()
+            .run(
+                &(vec(DOM, LEN), vec(DOM, LEN), DOM, DOM),
+                |(start, end, query_start, query_end)| {
+                    let tree = ITree::<_, _>::new(
+                        start
+                            .iter()
+                            .zip(&end)
+                            .map(|(&start, &end)| (start..end, ())),
+                    );
+
+                    let mut result1 = Vec::new();
+                    tree.query(query_start..=query_end, |(range, ())| {
+                        result1.push(range);
+                        ControlFlow::<()>::Continue(())
+                    })
+                    .continue_value()
+                    .unwrap();
+
+                    let mut result2 = tree
+                        .iter()
+                        .filter(|(range, ())| query_end >= range.start && query_start <= range.end)
+                        .map(|(range, ())| range)
+                        .collect::<Vec<_>>();
+
+                    result1.sort_unstable_by_key(|range| (range.start, range.end));
+                    result2.sort_unstable_by_key(|range| (range.start, range.end));
+                    assert_eq!(result1, result2);
+
+                    Ok(())
+                },
+            )
+            .unwrap()
+    }
+
     #[cfg(feature = "rayon")]
     #[test]
     fn par_query_random() {
@@ -216,6 +314,48 @@ mod tests {
                     let mut result2 = tree
                         .iter()
                         .filter(|(range, ())| query_end > range.start && query_start < range.end)
+                        .map(|(range, ())| range)
+                        .collect::<Vec<_>>();
+
+                    result1.sort_unstable_by_key(|range| (range.start, range.end));
+                    result2.sort_unstable_by_key(|range| (range.start, range.end));
+                    assert_eq!(result1, result2);
+
+                    Ok(())
+                },
+            )
+            .unwrap()
+    }
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn par_query_random_inclusive() {
+        const DOM: Range<i32> = -1000..1000;
+        const LEN: usize = 1000_usize;
+
+        TestRunner::default()
+            .run(
+                &(vec(DOM, LEN), vec(DOM, LEN), DOM, DOM),
+                |(start, end, query_start, query_end)| {
+                    let tree = ITree::<_, _>::par_new(
+                        start
+                            .iter()
+                            .zip(&end)
+                            .map(|(&start, &end)| (start..end, ())),
+                    );
+
+                    let result1 = Mutex::new(Vec::new());
+                    tree.par_query(query_start..=query_end, |(range, ())| {
+                        result1.lock().unwrap().push(range);
+                        ControlFlow::<()>::Continue(())
+                    })
+                    .continue_value()
+                    .unwrap();
+                    let mut result1 = result1.into_inner().unwrap();
+
+                    let mut result2 = tree
+                        .iter()
+                        .filter(|(range, ())| query_end >= range.start && query_start <= range.end)
                         .map(|(range, ())| range)
                         .collect::<Vec<_>>();
 


### PR DESCRIPTION
This affects only the query interface without any changes required to building the tree itself.